### PR TITLE
Migration Baumkataster 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ database:
   replace-table: True
 
 new-data-paths:
-  - tree_data/data_files/s_wfs_baumbestand.gml
-  - tree_data/data_files/s_wfs_baumbestand_an.gml
+  - tree_data/data_files/s_wfs_baumbestand.geojson
+  - tree_data/data_files/s_wfs_baumbestand_an.geojson
 
 data-schema:
   mapping:
@@ -62,13 +62,21 @@ PG_DB=
 
 ## Example Usage
 
-To save newest tree data from the FIS-Broker locally run
+1. Step: save newest tree data from the FIS-Broker locally run
 
 ```bash
 python tree_data/get_data_from_wfs.py
 ```
 
-To update database run
+2. Step: filename path in the conf.yml
+
+```yml
+new-data-paths:
+  - data_files/s_wfs_baumbestand_YYYY-M-D.geojson
+  - data_files/s_wfs_baumbestand_an_YYYY-M-D.geojson
+```
+
+1. Step: execute the main script to update the database
 
 ```bash
 python tree_data/main.py

--- a/README.md
+++ b/README.md
@@ -68,9 +68,11 @@ PG_DB=
 python tree_data/get_data_from_wfs.py
 ```
 
-2. Step: filename path in the conf.yml
+2. Step: set filename path and current year in the conf.yml
 
 ```yml
+year: 23
+
 new-data-paths:
   - data_files/s_wfs_baumbestand_YYYY-M-D.geojson
   - data_files/s_wfs_baumbestand_an_YYYY-M-D.geojson

--- a/README.md
+++ b/README.md
@@ -62,23 +62,25 @@ PG_DB=
 
 ## Example Usage
 
-1. Step: save newest tree data from the FIS-Broker locally run
+1. Step: Download newest tree data from the FIS-Broker. Locally run:
 
 ```bash
 python tree_data/get_data_from_wfs.py
 ```
 
-2. Step: set filename path and current year in the conf.yml
+2. Step: Set filename path and current year in the `conf.yml`
 
 ```yml
 year: 23
 
 new-data-paths:
-  - data_files/s_wfs_baumbestand_YYYY-M-D.geojson
-  - data_files/s_wfs_baumbestand_an_YYYY-M-D.geojson
+  - data_files/s_wfs_baumbestand_YYYY-MM-DD.geojson
+  - data_files/s_wfs_baumbestand_an_YYYY-MM-DD.geojson
 ```
 
-1. Step: execute the main script to update the database
+3. Setp: Configure you `.env` file and provide the credentials of your production database
+
+4. Step: Execute `main.py` to connect to your production database and finally update the database:
 
 ```bash
 python tree_data/main.py

--- a/tree_data/conf.yml
+++ b/tree_data/conf.yml
@@ -4,9 +4,12 @@ database:
   data-table-name: trees
   replace-table: True
 
+# will be added to the "id" of each tree
+year: 23
+
 new-data-paths:
-  - tree_data/data_files/s_wfs_baumbestand_apr22.geojson
-  - tree_data/data_files/s_wfs_baumbestand_an_apr22.geojson
+  - data_files/s_wfs_baumbestand_2023-5-4.geojson
+  - data_files/s_wfs_baumbestand_an_2023-5-4.geojson
 
 data-schema:
   mapping:

--- a/tree_data/get_data_from_wfs.py
+++ b/tree_data/get_data_from_wfs.py
@@ -1,8 +1,12 @@
 import geopandas as gpd
 from owslib.wfs import WebFeatureService
 from requests import Request
-import warnings
 import os, ssl
+from datetime import datetime
+
+currentDay = datetime.now().day
+currentMonth = datetime.now().month
+currentYear = datetime.now().year
 
 if (not os.environ.get('PYTHONHTTPSVERIFY', '') and
 getattr(ssl, '_create_unverified_context', None)):
@@ -24,28 +28,19 @@ def get_wfs(wfs_url, wfs_output_format, outfile_name):
     data.to_file(outfile_name + ".geojson", driver="GeoJSON")
     print('WFS was written to file' + outfile_name + ".geojson")
 
-
-    #ogr2ogr -f gpkg s_wfs_baumbestand_an.gpkg WFS:"https://fbinter.stadt-berlin.de/fb/wfs/data/senstadt/s_wfs_baumbestand_an" s_wfs_baumbestand_an
-
-    #ogr2ogr -f gpkg s_wfs_baumbestand_an.gpkg WFS:"https://fbinter.stadt-berlin.de/fb/wfs/data/senstadt/s_bparkplatz" s_wfs_baumbestand_an
-
-
-
 # set urls to wfs services
 wfs_trees_streets = 'https://fbinter.stadt-berlin.de/fb/wfs/data/senstadt/s_wfs_baumbestand'
 wfs_trees_parks = 'https://fbinter.stadt-berlin.de/fb/wfs/data/senstadt/s_wfs_baumbestand_an'
-#'https://fbinter.stadt-berlin.de/fb/wfs/data/senstadt/s_bparkplatz'
+
 # Specify the output Format of the WFS for fetching the data
 wfs_output_format = 'text/xml; subtype=gml/3.2.1'
-new_trees_streets_filename = "tree_data/data_files/s_wfs_baumbestand_apr22"
-new_trees_parks_filename = "tree_data/data_files/s_wfs_baumbestand_an_apr22"
 
-
+new_trees_streets_filename = "tree_data/data_files/s_wfs_baumbestand_" + str(currentYear) + "-" + str(currentMonth) + "-" + str(currentDay)
+new_trees_parks_filename = "tree_data/data_files/s_wfs_baumbestand_an_" + str(currentYear) + "-" + str(currentMonth) + "-" + str(currentDay)
 
 get_wfs(wfs_trees_streets, wfs_output_format, new_trees_streets_filename)
-#exit()
 get_wfs(wfs_trees_parks, wfs_output_format, new_trees_parks_filename)
 
-#new_trees.to_file(new_trees_filename + ".json", driver="GeoJSON")
+
 
 

--- a/tree_data/main.py
+++ b/tree_data/main.py
@@ -32,7 +32,6 @@ transformed_trees = transform_new_tree_data(new_trees, attribute_list, schema_ma
 updated_trees, deleted_trees, added_trees = compare_tree_data(transformed_trees, old_trees, update_attributes_list, merge_attributes_list, year)
 
 # Bring tree data changes to the database by updating the current tree table.
-logger.info("Interacting with database...")
 logger.info("Updating database...")
 update_db(conn, updated_trees, update_attributes_list, table_name)
 logger.info("Deleting old trees from database...")

--- a/tree_data/main.py
+++ b/tree_data/main.py
@@ -1,7 +1,7 @@
 import logging
-
+import time
 from utils.get_new_data import read_new_tree_data
-from utils.interact_with_database import start_db_connection, read_old_tree_data, update_db, delete_from_db, add_to_db
+from utils.interact_with_database import start_db_connection, read_old_tree_data, update_db, delete_from_db, add_to_db, drop_dublicates
 from utils.process_data import read_config, transform_new_tree_data, compare_tree_data
 
 # logger configuration
@@ -11,28 +11,36 @@ FORMAT = "[%(levelname)s %(name)s] %(message)s"
 logging.basicConfig(format=FORMAT)
 logger.setLevel(logging.DEBUG)
 
+# Start timer
+start = time.time()
 
 # Read parameters from config.yaml
-new_trees_paths_list, schema_mapping_dict, update_attributes_list, merge_attributes_list, database_dict = read_config()
+new_trees_paths_list, schema_mapping_dict, update_attributes_list, merge_attributes_list, database_dict, year = read_config()
 
 # Connect to the database. Database parameters are set in the .env
 conn = start_db_connection()
 # Import the current tree data from database. Name of the table is set in config.yaml
 old_trees, attribute_list, table_name = read_old_tree_data(conn, database_dict)
 
-
 # Import raw tree data as dataframe from files. Filenames are set in config.yaml
 new_trees = read_new_tree_data(new_trees_paths_list)
 # Transform new tree data to needed schema/format.
 transformed_trees = transform_new_tree_data(new_trees, attribute_list, schema_mapping_dict)
 
-
 # Compare new tree data with old tree data and save new, updated and deleted tree data.
 #updated_trees= compare_tree_data(transformed_trees, old_trees, update_attributes_list, merge_attributes_list)
-updated_trees, deleted_trees, added_trees = compare_tree_data(transformed_trees, old_trees, update_attributes_list, merge_attributes_list)
+updated_trees, deleted_trees, added_trees = compare_tree_data(transformed_trees, old_trees, update_attributes_list, merge_attributes_list, year)
+
 # Bring tree data changes to the database by updating the current tree table.
+logger.info("Interacting with database...")
+logger.info("Updating database...")
 update_db(conn, updated_trees, update_attributes_list, table_name)
-delete_from_db(conn, deleted_trees, update_attributes_list, table_name)
-add_to_db(conn, added_trees, update_attributes_list, table_name)
+logger.info("Deleting old trees from database...")
+delete_from_db(conn, deleted_trees, table_name)
+logger.info("Adding new trees to database...")
+add_to_db(conn, added_trees, table_name)
+#logger.info("Dropping gmlid dublicates...")
+#drop_dublicates(conn, table_name)
 
-
+end = time.time() - start
+logger.info("It took {} seconds to run the script".format(end))

--- a/tree_data/utils/process_data.py
+++ b/tree_data/utils/process_data.py
@@ -31,8 +31,9 @@ def read_config():
     merge_attributes_list = conf['data-schema']['merge-on']
     schema_mapping_dict = conf['data-schema']['mapping']
     database_dict = conf['database']
+    year = conf['year']
 
-    return new_trees_paths_list, schema_mapping_dict, update_attributes_list, merge_attributes_list, database_dict
+    return new_trees_paths_list, schema_mapping_dict, update_attributes_list, merge_attributes_list, database_dict, year
 
 def transform_new_tree_data(new_trees, attribute_list, schema_mapping_dict):
     """Takes the new tree data and extracts the data columns that are needed for comparision with old tree data. Does also change datatypes of some columns.
@@ -181,7 +182,7 @@ def find_deleted_trees(transformed_trees, old_trees, merge_attributes_list):
     return deleted_trees
 
 
-def find_added_trees(transformed_trees, old_trees, merge_attributes_list):
+def find_added_trees(transformed_trees, old_trees, merge_attributes_list, year):
 
     # only keep needed columns from old trees
     old_trees = old_trees[['id']+ merge_attributes_list]
@@ -195,7 +196,7 @@ def find_added_trees(transformed_trees, old_trees, merge_attributes_list):
     # create id's for new trees
     id_str = ""
     for i, column in enumerate(merge_attributes_list):
-        id_str += "_22" + added_trees[merge_attributes_list[i]].str.split(pat=":").str[1]
+        id_str += "_" + str(year) + added_trees[merge_attributes_list[i]].str.split(pat=":").str[1]
     added_trees['id'] = id_str
 
     #count number of added trees
@@ -219,7 +220,7 @@ def find_added_trees(transformed_trees, old_trees, merge_attributes_list):
     return added_trees
 
 
-def compare_tree_data(transformed_trees, old_trees, update_attributes_list,  merge_attributes_list):
+def compare_tree_data(transformed_trees, old_trees, update_attributes_list,  merge_attributes_list, year):
     """Compare the old and the new tree data to find changes.
 
     Args:
@@ -237,7 +238,7 @@ def compare_tree_data(transformed_trees, old_trees, update_attributes_list,  mer
 
     deleted_trees = find_deleted_trees(transformed_trees, old_trees, merge_attributes_list)
 
-    added_trees = find_added_trees(transformed_trees, old_trees, merge_attributes_list)
+    added_trees = find_added_trees(transformed_trees, old_trees, merge_attributes_list, year)
 
     updated_trees = find_updated_trees(transformed_trees, old_trees, update_attributes_list, merge_attributes_list)
  

--- a/tree_data/utils/process_data.py
+++ b/tree_data/utils/process_data.py
@@ -67,6 +67,11 @@ def transform_new_tree_data(new_trees, attribute_list, schema_mapping_dict):
             if column not in attribute_list:
                 transformed_trees = transformed_trees.drop([column], axis = 1)
 
+    duplicates_count = len(transformed_trees) - len(transformed_trees.drop_duplicates(subset=['gmlid']))
+
+    # drop duplicate features based on gmlid
+    transformed_trees = transformed_trees.drop_duplicates(subset=['gmlid'])
+
     # replace NA values with 'undefined' and transform dataformats to string
     for column in transformed_trees.columns:
         if column != "geometry":
@@ -84,6 +89,8 @@ def transform_new_tree_data(new_trees, attribute_list, schema_mapping_dict):
     # transformed_trees['kennzeich'] = transformed_trees['standortnr'].astype(str)
     # transformed_trees['standortnr'] = transformed_trees['standortnr_2'].astype(str)
     # transformed_trees = transformed_trees.drop(['standortnr_2'], axis=1)
+
+    logger.info("ℹ️" + str(duplicates_count) + " trees with a duplicated gmlid were dropped.")
 
     return transformed_trees
     

--- a/tree_data/utils/process_data.py
+++ b/tree_data/utils/process_data.py
@@ -44,14 +44,10 @@ def transform_new_tree_data(new_trees, attribute_list, schema_mapping_dict):
     Returns:
         transformed_trees (DataFrame): Extracted tree data.
     """
-
+    
     # if keeping the geometry column, transform data to the crs of our old tree dataset
     new_trees['geometry'] = new_trees['geometry'].set_crs("EPSG:25833", allow_override=True)
     new_trees['geometry'] = new_trees['geometry'].to_crs("EPSG:4326")
-
-
-    # in our case we don't use the geometry of the new data, so we can transform the geodataframe to a dataframe
-    #transformed_trees = pd.DataFrame(new_trees)
 
     # rename columns based on the columns of the old data
     transformed_trees = new_trees.rename(columns=schema_mapping_dict)
@@ -83,17 +79,10 @@ def transform_new_tree_data(new_trees, attribute_list, schema_mapping_dict):
 
     transformed_trees['lng'] = (transformed_trees.geometry.y).round(5).astype(str)
     transformed_trees['lat'] = (transformed_trees.geometry.x).round(5).astype(str)
- 
-    # in our current old data, standortnr and kennzeichen are reversed, so we have to reverse it here also
-    # transformed_trees['standortnr_2'] = transformed_trees['kennzeich']
-    # transformed_trees['kennzeich'] = transformed_trees['standortnr'].astype(str)
-    # transformed_trees['standortnr'] = transformed_trees['standortnr_2'].astype(str)
-    # transformed_trees = transformed_trees.drop(['standortnr_2'], axis=1)
 
-    logger.info("ℹ️" + str(duplicates_count) + " trees with a duplicated gmlid were dropped.")
-
+    logger.info("ℹ️ " + str(duplicates_count) + " trees with a duplicated gmlid were dropped.")
     return transformed_trees
-    
+
 
 def find_updated_trees(transformed_trees, old_trees, update_attributes_list,  merge_attributes_list):
 
@@ -102,32 +91,11 @@ def find_updated_trees(transformed_trees, old_trees, update_attributes_list,  me
     # find all trees that exist in old AND in the new dataset
     updated_trees = old_trees.merge(transformed_trees, on = merge_attributes_list, how ='inner', suffixes=("_x", None)) #125
 
-    # updated_trees2 = old_trees
-    # updated_trees2["standortnr"] = "0" + updated_trees2["standortnr"].astype(str)
-
-    # updated_trees2.to_file("tree_data/data_files/updated_trees_t.json", driver="GeoJSON")
-
-    # updated_trees2 = updated_trees2.merge(transformed_trees, left_on=merge_attributes_list, right_on = merge_attributes_list, how ='inner', suffixes=("_x", None))
-
-    # updated_trees3 = old_trees
-    # updated_trees3["standortnr"] = "0" + updated_trees3["standortnr"].astype(str)
-    # updated_trees3.to_file("tree_data/data_files/updated_trees_t2.json", driver="GeoJSON")
-    # updated_trees3 = updated_trees3.merge(transformed_trees, left_on=merge_attributes_list, right_on = merge_attributes_list, how ='inner', suffixes=("_x", None))
-
-    # updated_trees4 = old_trees
-    # updated_trees4["standortnr"] = "0" + updated_trees4["standortnr"].astype(str)
-    # updated_trees4 = updated_trees4.merge(transformed_trees, left_on=merge_attributes_list, right_on = merge_attributes_list, how ='inner', suffixes=("_x", None))
-
-    # updated_trees5 = old_trees
-    # updated_trees5["standortnr"] = "0" + updated_trees5["standortnr"].astype(str)
-    # updated_trees5 = updated_trees5.merge(transformed_trees, left_on=merge_attributes_list, right_on = merge_attributes_list, how ='inner', suffixes=("_x", None))
-    
-    # updated_trees = pd.concat([updated_trees,updated_trees2,updated_trees3,updated_trees4,updated_trees5])
-
     # count number of updated trees
     tree_count = len(updated_trees.index)
     if tree_count > 0:
         logger.info("🌲 Matched tree datasets: " + str(tree_count) + " matching trees were found.")
+
     # stop script if no updated trees were found
     else:
         msg = f"❌  No matching trees in old and new dataset were found. Something went wrong."
@@ -161,9 +129,7 @@ def find_updated_trees(transformed_trees, old_trees, update_attributes_list,  me
 def find_deleted_trees(transformed_trees, old_trees, merge_attributes_list):
 
     transformed_trees = pd.DataFrame(transformed_trees)
-   # print(transformed_trees.columns)
-    #print(old_trees.columns)
-    #print(merge_attributes_list)
+
     # find all trees that exist in the old BUT NOT in the new dataset
     deleted_trees = pd.merge(old_trees, transformed_trees, on = merge_attributes_list, how="left")
     deleted_trees = old_trees.merge(transformed_trees, on = merge_attributes_list, how='left')
@@ -244,9 +210,7 @@ def compare_tree_data(transformed_trees, old_trees, update_attributes_list,  mer
     """
 
     deleted_trees = find_deleted_trees(transformed_trees, old_trees, merge_attributes_list)
-
     added_trees = find_added_trees(transformed_trees, old_trees, merge_attributes_list, year)
-
     updated_trees = find_updated_trees(transformed_trees, old_trees, update_attributes_list, merge_attributes_list)
  
     return updated_trees, deleted_trees, added_trees

--- a/tree_data/utils/process_data.py
+++ b/tree_data/utils/process_data.py
@@ -83,7 +83,6 @@ def transform_new_tree_data(new_trees, attribute_list, schema_mapping_dict):
     # transformed_trees['standortnr'] = transformed_trees['standortnr_2'].astype(str)
     # transformed_trees = transformed_trees.drop(['standortnr_2'], axis=1)
 
-
     return transformed_trees
     
 
@@ -142,6 +141,10 @@ def find_updated_trees(transformed_trees, old_trees, update_attributes_list,  me
 
     # delete unused attributes
     updated_trees = updated_trees[update_attributes_list + ['id']]
+
+    # convert pflanzjahr of new tree cadastree according to db table strucutre whre pflanzjahr is an integer
+    updated_trees['pflanzjahr'] = updated_trees['pflanzjahr'].astype(int)
+
    # print("----")
     #print(updated_trees.geom.dtype)
    # print("----")


### PR DESCRIPTION
This Pull Request contains all changes that were made due to the new Baumkataster 2023 and our slightle new database schema. 

Changes are the following: 
- convert column 'pflanzjahr' to type `integer` accroding to new database schema and handle undefined or Null values
- add dynamic file naming to allow easier migrations in the future
- add `year` to the `conf.yml` to allow easier migrations in the future
- handle (basically drop) trees from the new tree cadastre that have a duplicated `gmlid`
- improved exception for better debugging
- update README.md